### PR TITLE
RPM build: Fix several issues (#610)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ The script will use a slightly modified Arch config from the `linux-tkg-config` 
 - Some issues have been reported by both Fedora (see https://github.com/Frogging-Family/linux-tkg/issues/383) and Ubuntu (see https://github.com/Frogging-Family/linux-tkg/issues/436) users where stock kernels cannot boot any longer, the whereabouts are still not entirely clear (it does not seem to affect every user)
   - Ubuntu: appears to be an initramfs generation issue
   - Fedora: needs disabling then re-enabling SELINUX so one can boot
-- Fedora + Nvidia users: Fedora's `akmod` nvidia packages do not work with `linux-tkg` (see https://github.com/Frogging-Family/linux-tkg/issues/375). `linux-tkg` requires Nvidias official `.run` installer (that uses `dkms` instead of `akmod`) to properly work with Nvidia.
 
 The interactive `install.sh` script will create, depending on the selected distro, `.deb` or `.rpm` packages, move them in the the subfolder `DEBS` or `RPMS` then prompts to install them with the distro's package manager.
 ```shell

--- a/install.sh
+++ b/install.sh
@@ -280,18 +280,18 @@ if [ "$1" = "install" ]; then
       else
         _kernelname=$_basekernel.${_kernel_subver}_$_kernel_flavor
       fi
-      _headers_rpm="kernel-headers-${_kernelname}*.rpm"
+
       _kernel_rpm="kernel-${_kernelname}*.rpm"
       # The headers are actually contained in the kernel-devel RPM and not the headers one...
       _kernel_devel_rpm="kernel-devel-${_kernelname}*.rpm"
 
       cd RPMS
       if [ "$_distro" = "Fedora" ]; then
-        sudo dnf install $_headers_rpm $_kernel_rpm $_kernel_devel_rpm
+        sudo dnf install $_kernel_rpm $_kernel_devel_rpm
       elif [ "$_distro" = "Suse" ]; then
         msg2 "Some files from 'linux-glibc-devel' will be replaced by files from the custom kernel-hearders package"
         msg2 "To revert back to the original kernel headers do 'sudo zypper install -f linux-glibc-devel'"
-        sudo zypper install --replacefiles --allow-unsigned-rpm $_headers_rpm $_kernel_rpm $_kernel_devel_rpm
+        sudo zypper install --allow-unsigned-rpm $_kernel_rpm $_kernel_devel_rpm
       fi
 
       msg2 "Install successful"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -673,6 +673,11 @@ _tkg_srcprep() {
   tkgpatch="$srcdir/0003-glitched-base.patch"
   _msg="Applying glitched base patch" && _tkg_patcher
 
+  if [[ "$_distro" =~ ^(Fedora|Suse)$ ]]; then
+    tkgpatch="$srcdir/0013-fedora-rpm.patch"
+    _msg="RPM: fixing spec generator" && _tkg_patcher
+  fi
+
   if [ -z $_misc_adds ]; then
     plain "Enable misc additions ? They may contain temporary fixes pending upstream, or some other changes that can break on non-Arch distros."
     read -rp "`echo $'    > [Y]/n : '`" _interactive_misc_adds;

--- a/linux-tkg-patches/5.10/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.10/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.11/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.11/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.12/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.12/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.13/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.13/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.14/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.14/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.15/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.15/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.16/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.16/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.17/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.17/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.18/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.18/0013-fedora-rpm.patch
@@ -1,0 +1,26 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.19/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.19/0013-fedora-rpm.patch
@@ -1,0 +1,26 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.4/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.4/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.7/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.7/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.8/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.8/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}

--- a/linux-tkg-patches/5.9/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.9/0013-fedora-rpm.patch
@@ -1,0 +1,27 @@
+# Remove the obsoletes line in kernel-headers
+# Add provides for kernel-devel so there's no conflict
+# and fix akmod-nvidia
+
+diff --git a/scripts/package/mkspec b/scripts/package/mkspec
+index 7c477ca7d..1158f5559 100755
+--- a/scripts/package/mkspec
++++ b/scripts/package/mkspec
+@@ -25,0 +26 @@ fi
++PROVIDES_DRM=""
+@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+-	PROVIDES=kernel-drm
++	PROVIDES_DRM="Provides: kernel-drm = %{version}"
+@@ -30 +30,0 @@ fi
+-PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
+@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Provides: $PROVIDES
++	$PROVIDES_DRM
++	Provides: kernel = %{version}
++	Provides: installonlypkg(kernel) = %{version}
+@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+-	Obsoletes: kernel-headers
++	Provides: installonlypkg(kernel) = %{version}
+@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
++$S$M	Provides: kernel-devel = %{version}
++$S$M	Provides: kernel-devel-uname-r = %{version}
++$S$M	Provides: installonlypkg(kernel) = %{version}


### PR DESCRIPTION
* RPM: fix the script that generates kernel.spec

- Avoids conflicts with official kernels
- Fixes the reported issues with "unversionned obsoletes"
- Works now with akmod-nvidia

Fixes: #609 #513 #375 #339 #375 #173 #271

Signed-off-by: Adel KARA SLIMANE <adel.ks@zegrapher.com>

* install.sh: RPM: do not install kernel-headers package

We do not need it to build out-of-tree kernel modules. And that's all we want actually.

Signed-off-by: Adel KARA SLIMANE <adel.ks@zegrapher.com>

Signed-off-by: Adel KARA SLIMANE <adel.ks@zegrapher.com>